### PR TITLE
Axe criticaldamagebonus

### DIFF
--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -316,7 +316,11 @@ namespace ACE.Server.Entity
 
                         if (Weapon != null && Weapon.IsTwoHanded)
                             CriticalChance += 0.05f + playerAttacker.ScaleWithPowerAccuracyBar(0.05f);
-
+                        
+                        /// Bonus to Axe for critical hit chance
+                        if (Weapon.Axe != Weapon.IsTwohanded)
+                            CriticalChance += 0.08f playerAttacker.ScaleWithPowerAccuracyBar(0.10f);
+                        
                         if (isAttackFromSneaking)
                         {
                             CriticalChance = 1.0f;
@@ -374,7 +378,7 @@ namespace ACE.Server.Entity
                     // verify: CriticalMultiplier only applied to the additional crit damage,
                     // whereas CD/CDR applied to the total damage (base damage + additional crit damage)
                     CriticalDamageMod = 1.0f + WorldObject.GetWeaponCritDamageMod(Weapon, attacker, attackSkill, defender, pkBattle);
-
+                    
                     CriticalDamageRatingMod = Creature.GetPositiveRatingMod(attacker.GetCritDamageRating());
 
                     // recklessness excluded from crits

--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -319,7 +319,7 @@ namespace ACE.Server.Entity
                         
                         /// Bonus to Axe for critical hit chance
                         if (Weapon.Axe != Weapon.IsTwohanded)
-                            CriticalChance += 0.08f playerAttacker.ScaleWithPowerAccuracyBar(0.10f);
+                            CriticalChance += 0.08f + playerAttacker.ScaleWithPowerAccuracyBar(0.08f);
                         
                         if (isAttackFromSneaking)
                         {
@@ -375,12 +375,16 @@ namespace ACE.Server.Entity
                 {
                     IsCritical = true;
 
+                     /// Axe bonus to criticaldamagemod
+                    if (weapon.Axe != Weapon.IsTwoHanded)
+                        CriticalDamageMod = 1.3f + WorldObject.GetWeaponCritDamageMod(Weapon, attacker, attackSkill, defender, pkBattle);
+
                     // verify: CriticalMultiplier only applied to the additional crit damage,
                     // whereas CD/CDR applied to the total damage (base damage + additional crit damage)
                     CriticalDamageMod = 1.0f + WorldObject.GetWeaponCritDamageMod(Weapon, attacker, attackSkill, defender, pkBattle);
                     
                     CriticalDamageRatingMod = Creature.GetPositiveRatingMod(attacker.GetCritDamageRating());
-
+                
                     // recklessness excluded from crits
                     RecklessnessMod = 1.0f;
                     DamageRatingMod = Creature.AdditiveCombine(DamageRatingBaseMod, CriticalDamageRatingMod, SneakAttackMod, HeritageMod, extraDamageMod);


### PR DESCRIPTION
Axe Critical Hit Chance increased w/increase to Critical Damage Bonus. Two-Handed axes DO NOT get this benefit.